### PR TITLE
Pull Docker image before withRun()

### DIFF
--- a/vars/groovylint.groovy
+++ b/vars/groovylint.groovy
@@ -20,6 +20,7 @@ void check(String includesPattern, groovylintImage = null) {
   }
   echo "Using groovylint Docker image: ${image.id}"
 
+  image.pull()
   image.withRun(
       "-v ${env.WORKSPACE}:/ws",
       "python3 /opt/run_codenarc.py -includes=${includesPattern}",


### PR DESCRIPTION
The documentation claims that explicitly calling pull() isn't
necessary, which is partially true because run/withRun/inside will
check to see that the image exists and call pull() if needed. However,
these functions only check that the image is present, not if a newer
one exists on the server. For that reason, we must call pull()
explicitly, since we overwrite tags on the server for major/minor
versions.

---

ptal @AbletonDevTools/gotham-city, thanks!