### PR TITLE
Update to ableton-utils 0.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 @Library([
-  'ableton-utils@0.10',
+  'ableton-utils@0.11',
 ]) _
 
 // Jenkins has some problems loading libraries from git references when they are


### PR DESCRIPTION
This is necessary because ableton-utils 0.10 uses an obsolete
credential used by the VersionTagger class.

---

ping @AbletonDevTools/gotham-city 