### PR TITLE
Convert Docker image to use Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM groovy:2.4
+FROM groovy:2.4-alpine
 
 USER root
 
@@ -6,25 +6,26 @@ ENV CODENARC_VERSION=1.2.1
 ENV SLF4J_VERSION=1.7.25
 ENV GMETRICS_VERSION=1.0
 
+
+# While the base Alpine image has a busybox-based wget, that version is not sophisticated
+# enough to download from Sourceforge et. al.
+RUN apk add --no-cache python3=3.6.5-r0 wget=1.19.5-r0
+
 RUN wget "https://netcologne.dl.sourceforge.net/project/codenarc/codenarc/CodeNarc%20$CODENARC_VERSION/CodeNarc-$CODENARC_VERSION.jar" \
     -P "/opt/CodeNarc-$CODENARC_VERSION"
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN wget -qO- "https://www.slf4j.org/dist/slf4j-$SLF4J_VERSION.tar.gz" | tar xvz -C /opt
+RUN wget -q -O slf4j.tar.gz "https://www.slf4j.org/dist/slf4j-$SLF4J_VERSION.tar.gz" && \
+    tar xvzf slf4j.tar.gz -C /opt && \
+    rm slf4j.tar.gz
 
 RUN wget "https://github.com/dx42/gmetrics/releases/download/v$GMETRICS_VERSION/GMetrics-$GMETRICS_VERSION.jar" \
     -P "/opt/GMetrics-$GMETRICS_VERSION"
-
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends python3=3.5.3-1 \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
 
 COPY codenarc /usr/bin
 COPY ruleset.groovy /opt/ruleset.groovy
 COPY run_codenarc.py /opt/run_codenarc.py
 
-RUN useradd jenkins
+RUN adduser -D jenkins
 USER jenkins
 
 WORKDIR /ws

--- a/codenarc
+++ b/codenarc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SLF4J_JAR=/opt/slf4j-$SLF4J_VERSION/slf4j-api-$SLF4J_VERSION.jar:/opt/slf4j-$SLF4J_VERSION/slf4j-simple-$SLF4J_VERSION.jar
 GMETRICS_JAR=/opt/GMetrics-$GMETRICS_VERSION/GMetrics-$GMETRICS_VERSION.jar


### PR DESCRIPTION
This closes https://github.com/AbletonAppDev/devtools/issues/1554. After this change, the Docker image size drops from 634mb to 197mb.

@ala-ableton @nre-ableton @rco-ableton ptal!