### PR TITLE
Use pipenv sync instead of pipenv install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY run_codenarc.py /opt/run_codenarc.py
 
 WORKDIR /opt
 RUN pip3 install --no-cache-dir pipenv==2018.11.26
-RUN pipenv install --system --deploy
+RUN pipenv install --system --ignore-pipfile
 
 RUN adduser -D jenkins
 USER jenkins

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ import com.ableton.VersionTagger as VersionTagger
 
 runTheBuilds.runDevToolsProject(
   setup: {
-    sh 'pipenv install --dev'
+    sh 'pipenv sync --dev'
   },
   build: { data ->
     String gitHash = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()


### PR DESCRIPTION
It turns out that pipenv install is an alias for lock + sync. This
causes the lockfile to be updated, meaning we may not be installing
the packages which we expect.

---

Related to https://github.com/AbletonAppDev/devtools/issues/1715, ping @AbletonDevTools/gotham-city 