### PR TITLE
Don't copy the Pipfile to the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN wget -q -O slf4j.tar.gz "https://www.slf4j.org/dist/slf4j-$SLF4J_VERSION.tar
 RUN wget "https://github.com/dx42/gmetrics/releases/download/v$GMETRICS_VERSION/GMetrics-$GMETRICS_VERSION.jar" \
     -P "/opt/GMetrics-$GMETRICS_VERSION"
 
-COPY Pipfile /opt
 COPY Pipfile.lock /opt
 COPY codenarc.sh /usr/bin
 COPY ruleset.groovy /opt/ruleset.groovy


### PR DESCRIPTION
We are actively ignoring the Pipfile when installing pip packages, so
there's no point in copying it to the container.

---

ping @AbletonDevTools/gotham-city 