### PR TITLE
Disable the CrapMetric

### DIFF
--- a/ruleset.groovy
+++ b/ruleset.groovy
@@ -34,6 +34,7 @@ ruleset {
     // This rule causes all sorts of CodeNarc crashes since version 1.1. We should
     // consider re-enabling it in the future when those are ironed out.
     AbcMetric(enabled: false)
+    CrapMetric(enabled: false)
     NestedBlockDepth(maxNestedBlockDepth: 8)
   }
   ruleset('rulesets/unnecessary.xml') {


### PR DESCRIPTION
This rule requires a Cobertura XML coverage file, which we should
provide with the coberturaXmlFile property. We don't have such a file,
so actually, this rule has never been working with groovylint.
Therefore we should just silence it.

---

ping @AbletonDevTools/gotham-city 