### PR TITLE
Simplify library loading

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,10 @@
   'ableton-utils@0.11',
 ]) _
 
-// Jenkins has some problems loading libraries from git references when they are
-// named 'origin/branch_name' or 'refs/heads/branch_name'. Until this behavior
-// is working, we need to strip those prefixes from the incoming HEAD_REF.
-String branch = "${env.HEAD_REF}".replace('origin/', '').replace('refs/heads/', '')
+// Jenkins can't load libraries from git references when they are named like
+// "refs/heads/branch_name". Until this behavior is fixed, we need to strip that prefix
+// from the branch name.
+String branch = "${env.HEAD_REF}".replace('refs/heads/', '')
 library "groovylint@${branch}"
 
 import com.ableton.VersionTagger as VersionTagger

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,7 @@
 // Jenkins can't load libraries from git references when they are named like
 // "refs/heads/branch_name". Until this behavior is fixed, we need to strip that prefix
 // from the branch name.
-String branch = "${env.HEAD_REF}".replace('refs/heads/', '')
-library "groovylint@${branch}"
+library "groovylint@${env.HEAD_REF.replace('refs/heads/', '')}"
 
 import com.ableton.VersionTagger as VersionTagger
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,17 +12,7 @@
 // Jenkins has some problems loading libraries from git references when they are
 // named 'origin/branch_name' or 'refs/heads/branch_name'. Until this behavior
 // is working, we need to strip those prefixes from the incoming HEAD_REF.
-String branch
-if (env.CHANGE_BRANCH) {
-  // Defined for PR-triggered events for a multibranch pipeline job
-  branch = env.CHANGE_BRANCH
-} else if (env.BRANCH_NAME) {
-  // Defined for all event triggers in a multibranch pipeline job
-  branch = env.BRANCH_NAME
-} else if (env.HEAD_REF) {
-  // Defined for a runthebuilds parameterized job
-  branch = "${env.HEAD_REF}".replace('origin/', '').replace('refs/heads/', '')
-}
+String branch = "${env.HEAD_REF}".replace('origin/', '').replace('refs/heads/', '')
 library "groovylint@${branch}"
 
 import com.ableton.VersionTagger as VersionTagger


### PR DESCRIPTION
This PR removes support for GitHub organization jobs, and also removes the replacement of `origin/` for the branch name, since that no longer seems to be necessary. ping @AbletonDevTools/gotham-city 