### PR TITLE
If the message is empty then the script doesn't generate the report

### DIFF
--- a/run_codenarc.py
+++ b/run_codenarc.py
@@ -104,12 +104,16 @@ def _print_violations(package_file_path, violations):
     :return: Number of violations for the file.
     """
     for violation in violations:
+        try:
+            message = violation.find('Message').text
+        except:
+            message = '[empty message]'
         logging.error(
             '%s:%s: %s: %s',
             package_file_path,
             violation.attrib['lineNumber'],
             violation.attrib['ruleName'],
-            violation.find('Message').text,
+            message,
         )
 
     return len(violations)


### PR DESCRIPTION
The below snippet:

```
void runTests(Map params) {
    ArrayList filesExclusions = params['filesExclusions']
    ArrayList groupsExclusions = params['groupsExclusions']
    ArrayList groupsSelection = params['groupsSelection']
```

Does generate an NoteType message:

```
Traceback (most recent call last):
  File "./run_codenarc.py", line 341, in <module>
    parse_xml_report(run_codenarc(parse_args(sys.argv[1:])))
  File "./run_codenarc.py", line 262, in parse_xml_report
    total_violations = _print_violations_in_packages(xml_doc.findall('Package'))
  File "./run_codenarc.py", line 156, in _print_violations_in_packages
    package.findall('File'),
  File "./run_codenarc.py", line 132, in _print_violations_in_files
    package_file.findall('Violation'),
  File "./run_codenarc.py", line 112, in _print_violations
    violation.find('Message').text,
AttributeError: 'NoneType' object has no attribute 'text'
/ws $ echo $?
1
```

The proposal PR does fix it and use a default message if Note, see the below output based on the above groovy
```
ERROR vars/script.groovy:138: ImplementationAsType: [empty message]
ERROR vars/script.groovy:139: ImplementationAsType: [empty message]
...
ERROR Found 6131 violation(s)
/ws $ echo $?
1
```