### PR TITLE
Remove pipenv check from Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,9 +37,6 @@ devToolsProject.run(
           sh 'hadolint /ws/Dockerfile'
         }
       },
-      pipenv: {
-        sh 'pipenv check'
-      },
       pydocstyle: {
         sh 'pipenv run pydocstyle -v'
       },


### PR DESCRIPTION
It turns out that pipenv check relies on a hardcoded API key to
pyup.io, which subjects us to the whims of rate limiting and other
policies from that service.

Until we have a better solution in place, we need to remove pipenv
check since it is still broken and the PIPENV_PYUP_API_KEY='' hack
doesn't seem to be working anymore either.

---

ping @AbletonDevTools/gotham-city