### PR TITLE
Remove unneeded pin

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,5 +3,4 @@ flake8
 flake8-isort
 pydocstyle
 pylint
-pyparsing!=2.4.1
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ pycodestyle==2.5.0        # via flake8
 pydocstyle==4.0.1
 pyflakes==2.1.1           # via flake8
 pylint==2.4.3
-pyparsing==2.4.3
+pyparsing==2.4.3          # via packaging
 pytest==5.2.2
 regex==2019.8.19          # via black
 six==1.12                 # via astroid, packaging


### PR DESCRIPTION
Now that we've moved past pyparsing 2.4.1, we can remove the pin.