### PR TITLE
fix: print the correct violation message

### DIFF
--- a/run_codenarc.py
+++ b/run_codenarc.py
@@ -105,7 +105,10 @@ def _print_violations(package_file_path, violations):
     """
     for violation in violations:
         message_element = violation.find('Message')
-        message = message_element.text if message_element else '[empty message]'
+        if message_element is not None:
+            message = message_element.text
+        else:
+            message = '[empty message]'
         logging.error(
             '%s:%s: %s: %s',
             package_file_path,


### PR DESCRIPTION
we don't want to rely on the boolean value of the xml element but on the
boolean value of the message contained in that element