### PR TITLE
Switch to latest groovy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ ENV SLF4J_VERSION=1.7.29
 ENV GMETRICS_VERSION=1.0
 
 RUN apt-get update && apt-get install --no-install-recommends --no-upgrade  -y \
-  python3-setuptools \
-  python3 \
-  python3-pip && \
+  python3-setuptools=39.0.1\* \
+  python3=3.6.7\* \
+  python3-pip=9.0.1\* && \
   rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /opt/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN python3 fetch_jars.py --output-dir /opt \
   --gmetrics-version $GMETRICS_VERSION \
   --slf4j-version $SLF4J_VERSION
 
-RUN useradd -ms /bin/bash -G staff jenkins
+RUN useradd -ms /bin/bash jenkins
 
 RUN mkdir /ws && \
   chown -R jenkins:jenkins /ws && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a MIT-style
 # license that can be found in the LICENSE file.
 
-FROM groovy:2.4-alpine
+FROM groovy:jre8
 
 USER root
 
@@ -11,7 +11,11 @@ ENV CODENARC_VERSION=1.5
 ENV SLF4J_VERSION=1.7.29
 ENV GMETRICS_VERSION=1.0
 
-RUN apk add --no-cache py3-setuptools~=39.1 python3~=3.6
+RUN apt-get update && apt-get install --no-install-recommends --no-upgrade  -y \
+  python3-setuptools \
+  python3 \
+  python3-pip && \
+  rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /opt/
 COPY fetch_jars.py /opt/
@@ -25,9 +29,14 @@ RUN python3 fetch_jars.py --output-dir /opt \
   --gmetrics-version $GMETRICS_VERSION \
   --slf4j-version $SLF4J_VERSION
 
-RUN adduser -D jenkins
-USER jenkins
+RUN useradd -ms /bin/bash -G staff jenkins
+
+RUN mkdir /ws && \
+  chown -R jenkins:jenkins /ws && \
+  chmod -R 700 /ws
 
 WORKDIR /ws
+
+USER jenkins
 
 CMD ["python3", "/opt/run_codenarc.py"]


### PR DESCRIPTION
We are using your groovylint image internally in our organization but I decided to make a few changes and re-build locally to have an in-house version.

I noticed that the upstream Groovy project has switched to a different tagging scheme and has dropped the alpine base images in their ongoing releases. They seem to now be using a debian base image. 

I've updated the Dockerfile for this project to take advantage of that, using jre8. This seems to work for me.

I noticed in your contributing guidelines you have a CLA that needs signing. I am not interested in doing so.

Feel free to merge this in or create a self-written update to your project using this code outside of this PR. That's up to you. I figured I'd contribute the reference code at the very least.

This now allows you to use the latest versions of the upstream groovy image at any jre you feel useful.

This does bump the built image from 184MB to 330MB :(