### PR TITLE
Temporarily disable SpaceAroundMapEntryColon rule

### DIFF
--- a/ruleset.groovy
+++ b/ruleset.groovy
@@ -24,7 +24,7 @@ ruleset {
     Indentation(spacesPerIndentLevel: 2, enabled: true)
     LineLength(length: 90)
     SpaceAfterOpeningBrace(ignoreEmptyBlock: true)
-    SpaceAroundMapEntryColon(characterAfterColonRegex: /\s/)
+    SpaceAroundMapEntryColon(enabled: false)
     SpaceBeforeClosingBrace(ignoreEmptyBlock: true)
   }
   ruleset('rulesets/generic.xml') {}


### PR DESCRIPTION
Something is wrong with the way this rule is behaving in CodeNarc 1.5;
we need to investigate (and hopefully see a fix for it in 1.6). Until
then, this rule should be disabled.
