### PR TITLE
Enforce f-strings with flake8-sfs

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,7 @@
 black==19.10b0
 flake8
 flake8-isort
+flake8-sfs
 pydocstyle
 pylint
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,8 @@ attrs==19.2.0             # via black, pytest
 black==19.10b0            # via -r requirements-dev.in
 click==7.0                # via black
 flake8-isort==3.0.0       # via -r requirements-dev.in
-flake8==3.8.1             # via -r requirements-dev.in, flake8-isort
+flake8-sfs==0.0.3         # via -r requirements-dev.in
+flake8==3.8.1             # via -r requirements-dev.in, flake8-isort, flake8-sfs
 isort[pyproject]==4.3.21  # via flake8-isort, pylint
 lazy-object-proxy==1.4.2  # via astroid
 mccabe==0.6.1             # via flake8, pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 filename = *.py
-ignore = W503
+ignore = SFS301, W503
 max-line-length = 90
 
 [isort]


### PR DESCRIPTION
SFS301 is the violation code for f-strings, by ignoring it we allow f-strings but reject other formatting styles recognized by flake8-sfs.