### PR TITLE
Improve logging of Java failures

### DIFF
--- a/run_codenarc.py
+++ b/run_codenarc.py
@@ -392,13 +392,20 @@ def run_codenarc(args, report_file=DEFAULT_REPORT_FILE):
     ] + extra_args
 
     logging.debug("Executing CodeNarc command: %s", " ".join(codenarc_call))
-    output = subprocess.run(
-        codenarc_call,
-        check=True,
-        cwd=cwd,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-    )
+    try:
+        output = subprocess.run(
+            codenarc_call,
+            check=True,
+            cwd=cwd,
+            stderr=subprocess.STDOUT,
+            stdout=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as error:
+        logging.error("Failed executing command: %s", " ".join(codenarc_call))
+        logging.error(
+            "CodeNarc exited with code %d: %s", error.returncode, error.stdout.decode()
+        )
+        raise
 
     # Trim out empty lines which CodeNarc prints in its output.
     codenarc_output = [x for x in output.stdout.decode().split("\n") if x != ""]


### PR DESCRIPTION
By default, CalledProcessError doesn't have much interesting
information in its message (usually just "[argument list] returned
non-zero exit status X."). This commit dumps the output from Java so
that it will hopefully be more obvious to users what the problem was.

---

This is probably the first PR in a series which aims to fix some mysterious
failures observed in groovylint as of the last few releases.
